### PR TITLE
fixed prophet error for same predictions for all locations

### DIFF
--- a/subseasonal_toolkit/models/prophet/prophet.ipynb
+++ b/subseasonal_toolkit/models/prophet/prophet.ipynb
@@ -151,7 +151,6 @@
     "            {\"ds\": new_df.reset_index()[\"start_date\"], \"y\": new_df.values})\n",
     "        print(df_single)\n",
     "        grid_df = pd.DataFrame()\n",
-    "        all_preds = []\n",
     "        m = Prophet(yearly_seasonality=True, weekly_seasonality=False)\n",
     "        num_periods = ((cur_date + DateOffset(months=4)) - cur_date).days\n",
     "        preds, _ = forecast(df_single, date, num_periods, start_delta, m)\n",


### PR DESCRIPTION
- extraneous line of code that create Prophet predictions to generate same values for every location on a given target date.